### PR TITLE
Prediction Updates

### DIFF
--- a/src/predictmod/apis/predict.py
+++ b/src/predictmod/apis/predict.py
@@ -54,37 +54,69 @@ class Predict(rest.Resource):
                 # end_time is the last timestamp to be send in the response
                 end_time = datetime.datetime.strptime(end_time, '%Y-%m-%dT%H:%M:%SZ')
 
-                predictions = model.forecast(K)
+                # Check wheather we already have predictions for the same timeframe using the same
+                # model.
+                found_predictions = db_helper.find_predictions(
+                    start_time=start_time, end_time=end_time,
+                    granularity='hour', model=str(active_model), is_valid=True
+                )
 
-                # Discard first S predictions since they are not required in the response
-                predictions_trimmed = predictions[S:]
-                ret = []
-                arr = []
-                t = start_time
-                for p in predictions_trimmed:
-                    arr.append(p)
-                    ret.append({'timestamp': t.strftime('%Y-%m-%dT%H:%M:%SZ'), 'requests': p})
-                    t += datetime.timedelta(hours=1)
+                if found_predictions is None or (
+                        found_predictions['generated_at'] < model_attributes['acquisition_time']
+                ):
+                    # Model has been retrained using newer input, we should generate new preditcions
+                    if found_predictions:
+                        db_helper.invalidate_predictions(found_predictions['_id'])
+                    predictions = model.forecast(K)
 
-                to_save = {
-                    'start_time': start_time,
-                    'end_time': end_time,
-                    'values': arr,
-                    'granularity': 'hour',
-                    'is_valid': True,
-                    'generated_at': utils.utcnow(),
-                    'model': active_model
-                }
-                inserted = mongo.db.predictions.insert_one(to_save)
-                if inserted.inserted_id:
-                    return flask.jsonify(
-                        {
-                            'id': str(inserted.inserted_id),
-                            'values': ret,
-                            'start_time': start_time.strftime('%Y-%m-%dT%H:%M:%SZ'),
-                            'end_time': end_time.strftime('%Y-%m-%dT%H:%M:%SZ')
-                        }
-                    )
+                    # Discard first S predictions since they are not required in the response
+                    predictions_trimmed = predictions[S:]
+                    ret = []
+                    arr = []
+                    t = start_time
+                    for p in predictions_trimmed:
+                        arr.append(p)
+                        ret.append({'timestamp': t.strftime('%Y-%m-%dT%H:%M:%SZ'), 'requests': p})
+                        t += datetime.timedelta(hours=1)
+
+                    to_save = {
+                        'start_time': start_time,
+                        'end_time': end_time,
+                        'values': arr,
+                        'granularity': 'hour',
+                        'is_valid': True,
+                        'generated_at': utils.utcnow(),
+                        'model': active_model
+                    }
+                    inserted = mongo.db.predictions.insert_one(to_save)
+                    if inserted.inserted_id:
+                        return flask.jsonify(
+                            {
+                                'id': str(inserted.inserted_id),
+                                'values': ret,
+                                'start_time': start_time.strftime('%Y-%m-%dT%H:%M:%SZ'),
+                                'end_time': end_time.strftime('%Y-%m-%dT%H:%M:%SZ'),
+                                'model': str(active_model),
+                                'generated_at': utils.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+                            }
+                        )
+                else:
+                    # Predictions we have are still valid, no need to generate new ones
+                    print >> sys.stderr, "Valid Predictions: ", found_predictions['generated_at']
+                    # Reformat predictions to expected response format
+                    t = start_time
+                    ret = []
+                    for p in found_predictions['values']:
+                        ret.append({'timestamp': t.strftime('%Y-%m-%dT%H:%M:%SZ'), 'requests': p})
+                        t += datetime.timedelta(hours=1)
+                    found_predictions['values'] = ret
+                    found_predictions['id'] = found_predictions['_id']
+                    # Hacky way of reformatting datetime
+                    found_predictions['generated_at'] = found_predictions['generated_at'][:-8] + "Z"
+                    del found_predictions['_id']
+                    del found_predictions['granularity']
+                    del found_predictions['is_valid']
+                    return flask.jsonify(found_predictions)
             else:
                 return flask.jsonify(
                     {

--- a/src/predictmod/db_helper.py
+++ b/src/predictmod/db_helper.py
@@ -63,6 +63,12 @@ def get_predictions_by_id(pred_id):
     return json.loads(encoder.encode(query_result))
 
 
+def find_predictions(**kwargs):
+    query_result = mongo.db.predictions.find_one(kwargs)
+    encoder = MongoEncoder()
+    return json.loads(encoder.encode(query_result))
+
+
 def save_predictions(obj):
     inserted = mongo.db.predictions.insert_one(obj)
     return str(inserted.inserted_id)


### PR DESCRIPTION
Improvements to the /predict endpoint:
- Validate start and end timestamps
- Caching predictions (return saved predictions for same timeframe as long as they are still valid)

Predictions are invalidated by the `notify_subscribers` job